### PR TITLE
Make reports attributes configurable

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -24,6 +24,8 @@ plugins:
     - name: start_date
       value: '2000-01-01'
     - name: metrics_log_level
+    - name: reports_attributes
+      kind: object
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-klaviyo"
-version = "0.0.5"
+version = "0.0.6"
 description = "`tap-klaviyo` is a Singer tap for Klaviyo, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Brooklyn Data"]

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -129,11 +129,12 @@ class CampaignValuesReportsStream(KlaviyoStream):
             context: dict | None,
             next_page_token: t.Optional[t.Any],
     ) -> dict | None:
+        report_attributes = self.config.get('reports_attributes', {}).get(self.name, {})
         return {
             "data": {
                 "type": "campaign-values-report",
                 "attributes": {
-                    "statistics": self.config['reports_attributes'].get(self.name, {}).get('statistics',[
+                    "statistics": report_attributes.get('statistics',[
                         "click_rate",
                         "click_to_open_rate",
                         "clicks",
@@ -150,10 +151,10 @@ class CampaignValuesReportsStream(KlaviyoStream):
                         "bounced",
                         "bounce_rate"
                         ]),
-                    "timeframe": self.config['reports_attributes'].get(self.name, {}).get('timeframe', {
+                    "timeframe": report_attributes.get('timeframe', {
                         "key": "last_365_days"
                     }),
-                    "conversion_metric_id": self.config['reports_attributes'].get(self.name, {}).get(
+                    "conversion_metric_id": report_attributes.get(
                         'conversion_metric_id', "WcGvVS"),
                 }
             }
@@ -445,11 +446,12 @@ class FlowValuesReportsStream(KlaviyoStream):
             context: dict | None,
             next_page_token: t.Optional[t.Any],
     ) -> dict | None:
+        report_attributes = self.config.get('reports_attributes', {}).get(self.name, {})
         return {
             "data": {
                 "type": "flow-values-report",
                 "attributes": {
-                    "statistics": self.config['reports_attributes'].get(self.name, {}).get('statistics', [
+                    "statistics": report_attributes.get('statistics', [
                         "click_rate",
                         "click_to_open_rate",
                         "clicks",
@@ -466,10 +468,10 @@ class FlowValuesReportsStream(KlaviyoStream):
                         "bounced",
                         "bounce_rate"
                     ]),
-                    "timeframe": self.config['reports_attributes'].get(self.name, {}).get('timeframe', {
+                    "timeframe": report_attributes.get('timeframe', {
                         "key": "yesterday"
                     }),
-                    "conversion_metric_id": self.config['reports_attributes'].get(self.name, {}).get(
+                    "conversion_metric_id": report_attributes.get(
                         'conversion_metric_id', "WcGvVS"),
                 }
             }

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -133,7 +133,7 @@ class CampaignValuesReportsStream(KlaviyoStream):
             "data": {
                 "type": "campaign-values-report",
                 "attributes": {
-                    "statistics": [
+                    "statistics": self.config['reports_attributes'].get(self.name, {}).get('statistics',[
                         "click_rate",
                         "click_to_open_rate",
                         "clicks",
@@ -149,11 +149,12 @@ class CampaignValuesReportsStream(KlaviyoStream):
                         "unsubscribes",
                         "bounced",
                         "bounce_rate"
-                        ],
-                    "timeframe": {
+                        ]),
+                    "timeframe": self.config['reports_attributes'].get(self.name, {}).get('timeframe', {
                         "key": "last_365_days"
-                    },
-                    "conversion_metric_id": "WcGvVS",
+                    }),
+                    "conversion_metric_id": self.config['reports_attributes'].get(self.name, {}).get(
+                        'conversion_metric_id', "WcGvVS"),
                 }
             }
         }
@@ -448,7 +449,7 @@ class FlowValuesReportsStream(KlaviyoStream):
             "data": {
                 "type": "flow-values-report",
                 "attributes": {
-                    "statistics": [
+                    "statistics": self.config['reports_attributes'].get(self.name, {}).get('statistics', [
                         "click_rate",
                         "click_to_open_rate",
                         "clicks",
@@ -464,11 +465,12 @@ class FlowValuesReportsStream(KlaviyoStream):
                         "unsubscribes",
                         "bounced",
                         "bounce_rate"
-                    ],
-                    "timeframe": {
+                    ]),
+                    "timeframe": self.config['reports_attributes'].get(self.name, {}).get('timeframe', {
                         "key": "yesterday"
-                    },
-                    "conversion_metric_id": "WcGvVS",
+                    }),
+                    "conversion_metric_id": self.config['reports_attributes'].get(self.name, {}).get(
+                        'conversion_metric_id', "WcGvVS"),
                 }
             }
         }

--- a/tap_klaviyo/tap.py
+++ b/tap_klaviyo/tap.py
@@ -40,7 +40,25 @@ class TapKlaviyo(Tap):
             th.StringType,
             description="The log level for the metrics stream",
             default="INFO"
-        )
+        ),
+        th.Property(
+            "reports_attributes",
+            th.ObjectType(
+                th.Property('campaign_values_reports', th.ObjectType(
+                    th.Property('statistics', th.ArrayType(th.StringType)),
+                    th.Property('timeframe',
+                                th.ObjectType(
+                                    th.Property('key', th.StringType), additional_properties=False)),
+                    th.Property('conversion_metric_id', th.StringType), additional_properties=False)),
+                th.Property('flow_values_reports', th.ObjectType(
+                    th.Property('statistics', th.ArrayType(th.StringType)),
+                    th.Property('timeframe',
+                                th.ObjectType(
+                                    th.Property('key', th.StringType), additional_properties=False)),
+                    th.Property('conversion_metric_id', th.StringType), additional_properties=False)
+            ), additional_properties=False),
+            description="Redefine report attributes (e.g. {'campaign_values_reports': {'statistics: ['click_rate']}} )",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> list[streams.KlaviyoStream]:


### PR DESCRIPTION
This change will allow configuring the report attributes (statistics,  timeframe, and conversion_metric_id) using the extractor config.

Tested locally with `campaign_values_reports` and `flow_values_reports`.