### PR TITLE
Adjust rate limit in the `flow_value_reports` stream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-klaviyo"
-version = "1.0.0"
+version = "1.0.1"
 description = "`tap-klaviyo` is a Singer tap for Klaviyo, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Brooklyn Data"]

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -90,7 +90,7 @@ class KlaviyoStream(RESTStream):
 
     def backoff_wait_generator(self) -> t.Generator[float, None, None]:
         def _backoff_from_headers(retriable_api_error):
-            response_headers = retriable_api_error.response.headers
+            response_headers = retriable_api_error.response.headers if retriable_api_error.response else {}
             return int(response_headers.get("Retry-After", 60))
 
         return self.backoff_runtime(value=_backoff_from_headers)

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -90,7 +90,7 @@ class KlaviyoStream(RESTStream):
 
     def backoff_wait_generator(self) -> t.Generator[float, None, None]:
         def _backoff_from_headers(retriable_api_error):
-            response_headers = retriable_api_error.response.headers if retriable_api_error.response else {}
+            response_headers = retriable_api_error.response.headers
             return int(response_headers.get("Retry-After", 60))
 
         return self.backoff_runtime(value=_backoff_from_headers)

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import typing as t
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
+from time import sleep
 
 import requests
 from singer_sdk.helpers.jsonpath import extract_jsonpath
@@ -496,6 +497,7 @@ class FlowValuesReportsStream(KlaviyoStream):
             context['end'] = current_date.replace(hour=23, minute=59, second=59, microsecond=99)
             yield from super().get_records(context)
             current_date += timedelta(days=1)
+            sleep(31)  # 2/m rate limit
         else:
             self.logger.info(f'Last available daily report already extracted')
 


### PR DESCRIPTION
This includes a sleep to avoid hitting the rate limit in `flows_value_reports` as every request during the cool-down period is also counted as a request and reduced from the remaining limit.